### PR TITLE
win: fix can not find primary monitor crash

### DIFF
--- a/ui/display/win/screen_win.cc
+++ b/ui/display/win/screen_win.cc
@@ -367,7 +367,9 @@ std::vector<ScreenWinDisplay> DisplayInfosToScreenWinDisplays(
       display_infos_remaining, [](const internal::DisplayInfo& display_info) {
         return display_info.screen_rect().origin().IsOrigin();
       });
-  DCHECK(primary_display_iter != display_infos_remaining.end());
+  if (primary_display_iter == display_infos_remaining.end()) {
+    return {};
+  }
 
   // Build the tree and determine DisplayPlacements along the way.
   DisplayLayoutBuilder builder(primary_display_iter->id());


### PR DESCRIPTION
may fix https://bugs.chromium.org/p/chromium/issues/detail?id=1436572